### PR TITLE
Potential fix for code scanning alert no. 18: Useless regular-expression character escape

### DIFF
--- a/public/games/arcticescape/Build/ArcticEscape_1.loader.js
+++ b/public/games/arcticescape/Build/ArcticEscape_1.loader.js
@@ -271,8 +271,8 @@ function createUnityInstance(canvas, config, onProgress) {
     var oses = [
       ['Windows (.*?)[;\)]', 'Windows'],
       ['Android ([0-9_\.]+)', 'Android'],
-      ['iPhone OS ([0-9_\.]+)', 'iPhoneOS'],
-      ['iPad.*? OS ([0-9_\.]+)', 'iPadOS'],
+      ['iPhone OS ([0-9_.]+)', 'iPhoneOS'],
+      ['iPad.*? OS ([0-9_.]+)', 'iPadOS'],
       ['FreeBSD( )', 'FreeBSD'],
       ['OpenBSD( )', 'OpenBSD'],
       ['Linux|X11()', 'Linux'],


### PR DESCRIPTION
Potential fix for [https://github.com/syl3n7/portfolio/security/code-scanning/18](https://github.com/syl3n7/portfolio/security/code-scanning/18)

To fix the problem, we need to remove the unnecessary escape sequence `\.` from the regular expression on line 275. This can be done by simply replacing `\.` with `.`. This change will not affect the functionality of the code, as the dot character will still match any character except a newline.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
