### PR TITLE
Potential fix for code scanning alert no. 17: Useless regular-expression character escape

### DIFF
--- a/public/games/arcticescape/Build/ArcticEscape_1.loader.js
+++ b/public/games/arcticescape/Build/ArcticEscape_1.loader.js
@@ -270,9 +270,9 @@ function createUnityInstance(canvas, config, onProgress) {
     // These OS strings need to match the ones in Runtime/Misc/SystemInfo.cpp::GetOperatingSystemFamily()
     var oses = [
       ['Windows (.*?)[;\)]', 'Windows'],
-      ['Android ([0-9_\.]+)', 'Android'],
-      ['iPhone OS ([0-9_\.]+)', 'iPhoneOS'],
-      ['iPad.*? OS ([0-9_\.]+)', 'iPadOS'],
+      ['Android ([0-9_.]+)', 'Android'],
+      ['iPhone OS ([0-9_.]+)', 'iPhoneOS'],
+      ['iPad.*? OS ([0-9_.]+)', 'iPadOS'],
       ['FreeBSD( )', 'FreeBSD'],
       ['OpenBSD( )', 'OpenBSD'],
       ['Linux|X11()', 'Linux'],


### PR DESCRIPTION
Potential fix for [https://github.com/syl3n7/portfolio/security/code-scanning/17](https://github.com/syl3n7/portfolio/security/code-scanning/17)

To fix the problem, we need to remove the unnecessary backslash from the escape sequence `\.` in the regular expression. This will ensure that the regular expression is clear and does not contain redundant escape sequences. The change should be made in the file `public/games/arcticescape/Build/ArcticEscape_1.loader.js` on line 274.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
