### PR TITLE
Potential fix for code scanning alert no. 16: Useless regular-expression character escape

### DIFF
--- a/public/games/arcticescape/Build/ArcticEscape_1.loader.js
+++ b/public/games/arcticescape/Build/ArcticEscape_1.loader.js
@@ -270,9 +270,9 @@ function createUnityInstance(canvas, config, onProgress) {
     // These OS strings need to match the ones in Runtime/Misc/SystemInfo.cpp::GetOperatingSystemFamily()
     var oses = [
       ['Windows (.*?)[;\)]', 'Windows'],
-      ['Android ([0-9_\.]+)', 'Android'],
-      ['iPhone OS ([0-9_\.]+)', 'iPhoneOS'],
-      ['iPad.*? OS ([0-9_\.]+)', 'iPadOS'],
+      ['Android ([0-9_.]+)', 'Android'],
+      ['iPhone OS ([0-9_.]+)', 'iPhoneOS'],
+      ['iPad.*? OS ([0-9_.]+)', 'iPadOS'],
       ['FreeBSD( )', 'FreeBSD'],
       ['OpenBSD( )', 'OpenBSD'],
       ['Linux|X11()', 'Linux'],


### PR DESCRIPTION
Potential fix for [https://github.com/syl3n7/portfolio/security/code-scanning/16](https://github.com/syl3n7/portfolio/security/code-scanning/16)

To fix the problem, we need to remove the unnecessary escape sequence `\.` and replace it with a plain dot `.` in the regular expression. This change will ensure that the dot is correctly interpreted as a literal character in the context of the regular expression.

- Locate the regular expression patterns in the `oses` array where `\.` is used.
- Replace `\.` with `.` to remove the superfluous escape sequence.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
