### PR TITLE
Potential fix for code scanning alert no. 14: Incomplete string escaping or encoding

### DIFF
--- a/public/games/arcticescape/Build/ArcticEscape_1.framework.js
+++ b/public/games/arcticescape/Build/ArcticEscape_1.framework.js
@@ -1965,6 +1965,7 @@ var ASM_CONSTS = {
   		}
   
   		// Fallback: Escape special characters with RegExp. This handles most cases but not all!
+  		id = id.replace(/\\/g, "\\\\");
   		return id.replace(/(#|\.|\+|\[|\]|\(|\)|\{|\})/g, "\\$1");
   	}
   function jsCanvasSelector() {


### PR DESCRIPTION
Potential fix for [https://github.com/syl3n7/portfolio/security/code-scanning/14](https://github.com/syl3n7/portfolio/security/code-scanning/14)

To fix the problem, we need to ensure that backslashes are also escaped in the `id.replace` method. This can be done by adding an additional replacement for backslashes before handling other special characters. We will use a regular expression with the global flag to ensure all occurrences are replaced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
